### PR TITLE
feat: add nextjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,20 @@ npm i route-list -g
 ## 🔌 Configuration
 
 ### Traditional Frameworks
-Before you can use `route-list` on your project, we first need to make sure it's configured properly.
-In order for `route-list` to work, we need to export server "app".
-The example below is for Express but it also applies to Koa (with @koa/router)/Hapi/Fastify.
+
+Before you can use `route-list` on your project, we first need to make sure it's
+configured properly. In order for `route-list` to work, we need to export server
+"app". The example below is for Express but it also applies to Koa (with
+@koa/router)/Hapi/Fastify.
 
 **app.js** / **app.ts**
 
 ```js
 const app = express();
 
-app.get('/', (req, res) => res.sendStatus(200));
-app.get('/products', (req, res) => res.sendStatus(200));
-app.get('/products/:id', (req, res) => res.sendStatus(200));
+app.get("/", (req, res) => res.sendStatus(200));
+app.get("/products", (req, res) => res.sendStatus(200));
+app.get("/products/:id", (req, res) => res.sendStatus(200));
 
 // CJS
 // Option 1: module.exports = app;
@@ -43,19 +45,25 @@ app.get('/products/:id', (req, res) => res.sendStatus(200));
 // Option 3: export default functionThatReturnsApp;
 ```
 
-> NOTE: In case you use [SocketIO with Express](https://socket.io/get-started/chat#the-web-framework), make sure to **export Express app**, not `http.createServer` server instance.
+> NOTE: In case you use
+> [SocketIO with Express](https://socket.io/get-started/chat#the-web-framework),
+> make sure to **export Express app**, not `http.createServer` server instance.
 
 ### Next.js App Router
-For Next.js applications using the App Router (13+), `route-list` will automatically detect and list your API routes. Your API routes should follow Next.js conventions:
+
+For Next.js applications using the App Router (13+), `route-list` will
+automatically detect and list your API routes. Your API routes should follow
+Next.js conventions:
 
 **app/api/users/route.ts**
+
 ```ts
 export async function GET(request: Request) {
-  return new Response('GET users');
+    return new Response("GET users");
 }
 
 export async function POST(request: Request) {
-  return new Response('Create user');
+    return new Response("Create user");
 }
 ```
 
@@ -87,14 +95,14 @@ route-list app/api --methods GET,POST     # Show only GET and POST routes
 ## 💻 Programmatic Usage
 
 ```js
-import RouteList from 'route-list';
+import RouteList from "route-list";
 
 // For traditional frameworks
-const routesMap = RouteList.getRoutes(app, 'express');
+const routesMap = RouteList.getRoutes(app, "express");
 // Example result: { "/": ["GET"], "/users": ["GET", "POST"] }
 
 // For Next.js
-const routesMap = RouteList.getRoutes('app/api', 'next');
+const routesMap = RouteList.getRoutes("app/api", "next");
 // Example result: { "/users": ["GET", "POST"], "/users/:id": ["GET", "PUT"] }
 
 // Print routes to console
@@ -104,18 +112,21 @@ RouteList.printRoutes(routesMap);
 ## 🚀 Framework Support
 
 ### Traditional Frameworks
+
 - Express
 - Koa (with @koa/router or koa-router)
 - Hapi
 - Fastify
 
 ### Next.js
+
 - Supports Next.js 13+ (App Router)
 - Automatically detects API routes in app/api directory
 - Supports dynamic routes ([param] -> :param)
 - Detects HTTP methods from route handlers
 - Example structure:
-  ```
+
+  ```plaintext
   app/
   └── api/
       ├── users/
@@ -138,15 +149,17 @@ Contributions, issues and feature requests are welcome!
 
 ## 🍻 Credits
 
-The project was inspired by new `route:list` command in Laravel 9.
-New [`route:list`](https://github.com/laravel/framework/pull/40269) itself was
-inspired by [`pretty-routes`](https://github.com/Wulfheart/pretty-routes) project.
-Big thanks to [Λlex Wulf](https://twitter.com/alexfwulf) for building
-`pretty-routes` and Laravel community for recognizing the usefulness of the project.
+The project was inspired by new `route:list` command in Laravel 9. New
+[`route:list`](https://github.com/laravel/framework/pull/40269) itself was
+inspired by [`pretty-routes`](https://github.com/Wulfheart/pretty-routes)
+project. Big thanks to [Λlex Wulf](https://twitter.com/alexfwulf) for building
+`pretty-routes` and Laravel community for recognizing the usefulness of the
+project.
 
 ## ✏️ License
 
-This project is licensed under [MIT](https://opensource.org/licenses/MIT) license.
+This project is licensed under [MIT](https://opensource.org/licenses/MIT)
+license.
 
 ## 👨‍🚀 Show your support
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/VladimirMikulic/route-list/actions/workflows/ci.yml/badge.svg)](https://github.com/VladimirMikulic/route-list/actions)
 [![Twitter: VladoDev](https://img.shields.io/twitter/follow/VladoDev.svg?style=social)](https://twitter.com/VladoDev)
 
-> ✨ Beautifully shows Express/Koa/Hapi/Fastify routes in CLI.
+> ✨ Beautifully shows Express/Koa/Hapi/Fastify/Next.js routes in CLI.
 
 ![route-list CLI example](./screenshots/showcase.png)
 
@@ -18,6 +18,7 @@ npm i route-list -g
 
 ## 🔌 Configuration
 
+### Traditional Frameworks
 Before you can use `route-list` on your project, we first need to make sure it's configured properly.
 In order for `route-list` to work, we need to export server "app".
 The example below is for Express but it also applies to Koa (with @koa/router)/Hapi/Fastify.
@@ -44,6 +45,20 @@ app.get('/products/:id', (req, res) => res.sendStatus(200));
 
 > NOTE: In case you use [SocketIO with Express](https://socket.io/get-started/chat#the-web-framework), make sure to **export Express app**, not `http.createServer` server instance.
 
+### Next.js App Router
+For Next.js applications using the App Router (13+), `route-list` will automatically detect and list your API routes. Your API routes should follow Next.js conventions:
+
+**app/api/users/route.ts**
+```ts
+export async function GET(request: Request) {
+  return new Response('GET users');
+}
+
+export async function POST(request: Request) {
+  return new Response('Create user');
+}
+```
+
 ## ☁️ Usage
 
 ### Options
@@ -56,15 +71,15 @@ app.get('/products/:id', (req, res) => res.sendStatus(200));
 ### Examples
 
 ```sh
+# Traditional frameworks (Express, Koa, Hapi, Fastify)
 route-list server/app.js
-```
-
-```sh
 route-list --group server/app.js
-```
-
-```sh
 route-list --methods GET,POST server/app.js
+
+# Next.js App Router (13+)
+route-list app/api                        # List all API routes
+route-list app/api --group                # Group API routes by path
+route-list app/api --methods GET,POST     # Show only GET and POST routes
 ```
 
 > NOTE: In case an app is part of NX monorepo, make sure to build it first.
@@ -74,12 +89,40 @@ route-list --methods GET,POST server/app.js
 ```js
 import RouteList from 'route-list';
 
-// Example result { "/": ["GET"], "/users": ["GET", "POST"] }
+// For traditional frameworks
 const routesMap = RouteList.getRoutes(app, 'express');
+// Example result: { "/": ["GET"], "/users": ["GET", "POST"] }
+
+// For Next.js
+const routesMap = RouteList.getRoutes('app/api', 'next');
+// Example result: { "/users": ["GET", "POST"], "/users/:id": ["GET", "PUT"] }
 
 // Print routes to console
 RouteList.printRoutes(routesMap);
 ```
+
+## 🚀 Framework Support
+
+### Traditional Frameworks
+- Express
+- Koa (with @koa/router or koa-router)
+- Hapi
+- Fastify
+
+### Next.js
+- Supports Next.js 13+ (App Router)
+- Automatically detects API routes in app/api directory
+- Supports dynamic routes ([param] -> :param)
+- Detects HTTP methods from route handlers
+- Example structure:
+  ```
+  app/
+  └── api/
+      ├── users/
+      │   └── route.ts      # GET, POST /users
+      └── users/[id]/
+          └── route.ts      # GET, PUT /users/:id
+  ```
 
 ## 👨 Author
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,6 @@
+export const NEXT_FRAMEWORK = 'next';
+export const EXPRESS_FRAMEWORK = 'express';
+export const KOA_FRAMEWORK = 'koa';
+export const HAPI_FRAMEWORK = 'hapi';
+export const FASTIFY_FRAMEWORK = 'fastify';
+

--- a/src/routes.js
+++ b/src/routes.js
@@ -107,12 +107,9 @@ const getFastifyRoutes = app => {
 const getNextRoutes = (appDir) => {
   const routesMap = {};
   const apiDir = appDir;
-  console.log('Looking for API routes in:', apiDir);
   
   function processDirectory(currentPath, parentRoute = '') {
-    console.log('Processing directory:', currentPath);
     const items = fs.readdirSync(currentPath);
-    console.log('Found items:', items);
     
     for (const item of items) {
       const fullPath = path.join(currentPath, item);
@@ -131,7 +128,6 @@ const getNextRoutes = (appDir) => {
         if (['route.js', 'route.tsx', 'route.ts'].includes(item)) {
           // No need to add /api prefix since we're already in the api directory
           const route = parentRoute || '/';
-          console.log('Found route file:', fullPath);
           // Read the file content to detect HTTP methods
           const content = fs.readFileSync(fullPath, 'utf8');
           const methods = [];
@@ -143,7 +139,6 @@ const getNextRoutes = (appDir) => {
           if (content.includes('export const DELETE') || content.includes('export async function DELETE')) methods.push('DELETE');
           if (content.includes('export const PATCH') || content.includes('export async function PATCH')) methods.push('PATCH');
           
-          console.log('Detected methods:', methods);
           routesMap[route] = methods;
         }
       }
@@ -152,10 +147,7 @@ const getNextRoutes = (appDir) => {
 
   if (fs.existsSync(apiDir)) {
     processDirectory(apiDir);
-  } else {
-    console.log('API directory not found:', apiDir);
   }
 
-  console.log('Final routesMap:', routesMap);
   return routesMap;
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { EXPRESS_FRAMEWORK, FASTIFY_FRAMEWORK, HAPI_FRAMEWORK, KOA_FRAMEWORK, NEXT_FRAMEWORK } from './constants.js';
 
 export const getAppWorkingDirPath = appFilePath => {
   let lastParsedPath = path.parse(appFilePath);
@@ -21,18 +22,19 @@ export const getFrameworkName = appWorkingDirPath => {
   const pkgJSON = JSON.parse(fs.readFileSync(pkgJSONFilePath));
   const { dependencies } = pkgJSON;
 
-  if (dependencies.express) return 'express';
-  if (dependencies.koa && dependencies['@koa/router']) return 'koa';
-  if (dependencies.koa && dependencies['koa-router']) return 'koa';
-  if (dependencies['@hapi/hapi']) return 'hapi';
-  if (dependencies.fastify) return 'fastify';
+  if (dependencies.next) return NEXT_FRAMEWORK;
+  if (dependencies.express) return EXPRESS_FRAMEWORK;
+  if (dependencies.koa && dependencies['@koa/router']) return KOA_FRAMEWORK;
+  if (dependencies.koa && dependencies['koa-router']) return KOA_FRAMEWORK;
+  if (dependencies['@hapi/hapi']) return HAPI_FRAMEWORK;
+  if (dependencies.fastify) return FASTIFY_FRAMEWORK;
   return null;
 };
 
 // See README for different export options
 export const getApp = (appExport, frameworkName) => {
   // hapi app instance also has an internal "app" property
-  if (frameworkName === 'hapi')
+  if (frameworkName === HAPI_FRAMEWORK)
     return appExport.app?.app ? appExport.app : appExport;
   return appExport.app || appExport;
 };

--- a/test/fixtures/next-app/app/about/page.js
+++ b/test/fixtures/next-app/app/about/page.js
@@ -1,0 +1,1 @@
+// About page 

--- a/test/fixtures/next-app/app/api/users/route.js
+++ b/test/fixtures/next-app/app/api/users/route.js
@@ -1,0 +1,19 @@
+export async function GET(request) {
+  return new Response('GET users');
+}
+
+export async function POST(request) {
+  return new Response('Create user');
+}
+
+export async function PUT(request) {
+  return new Response('Update user');
+}
+
+export async function DELETE(request) {
+  return new Response('Delete user');
+}
+
+export async function PATCH(request) {
+  return new Response('Patch user');
+} 

--- a/test/fixtures/next-app/app/page.js
+++ b/test/fixtures/next-app/app/page.js
@@ -1,0 +1,1 @@
+// Home page 

--- a/test/fixtures/next-app/app/users/[id]/page.js
+++ b/test/fixtures/next-app/app/users/[id]/page.js
@@ -1,0 +1,1 @@
+// User detail page 

--- a/test/fixtures/next-app/app/users/page.js
+++ b/test/fixtures/next-app/app/users/page.js
@@ -1,0 +1,1 @@
+// Users list page 

--- a/test/fixtures/next-app/package.json
+++ b/test/fixtures/next-app/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "next-app",
+  "type": "module",
+  "dependencies": {
+    "next": "^14.0.0"
+  }
+} 

--- a/test/next.test.js
+++ b/test/next.test.js
@@ -11,8 +11,6 @@ const __dirname = path.dirname(__filename);
 const MOCK_NEXT_APP_PATH = path.join(__dirname, 'fixtures/next-app/app/api');
 
 test('Next.js Routes', () => {
-  console.log('Test directory:', MOCK_NEXT_APP_PATH);
-  console.log('API directory exists:', fs.existsSync(path.join(MOCK_NEXT_APP_PATH, 'api')));
   
   const actualRoutesMap = getRoutes(MOCK_NEXT_APP_PATH, "next");
   const expectedRoutesMap = {

--- a/test/next.test.js
+++ b/test/next.test.js
@@ -1,0 +1,23 @@
+import assert from 'assert';
+import test from 'node:test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { getRoutes } from '../src/routes.js';
+import fs from 'fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const MOCK_NEXT_APP_PATH = path.join(__dirname, 'fixtures/next-app/app/api');
+
+test('Next.js Routes', () => {
+  console.log('Test directory:', MOCK_NEXT_APP_PATH);
+  console.log('API directory exists:', fs.existsSync(path.join(MOCK_NEXT_APP_PATH, 'api')));
+  
+  const actualRoutesMap = getRoutes(MOCK_NEXT_APP_PATH, "next");
+  const expectedRoutesMap = {
+    '/users': ['GET', 'POST', 'PUT', 'DELETE', 'PATCH']
+  };
+
+  assert.deepStrictEqual(actualRoutesMap, expectedRoutesMap);
+}); 


### PR DESCRIPTION
# Add Next.js App Router API Routes Support

This PR adds support for Next.js App Router API routes, making it easy for Next.js developers to list and inspect their API endpoints. The implementation follows Next.js's App Router conventions and provides a seamless experience for viewing API routes.

## Changes
- Added Next.js App Router support (13+)
- Added automatic HTTP method detection from route handlers
- Added support for dynamic routes ([param] -> :param)
- Moved framework names to constants.js for better maintainability
- Updated documentation with Next.js examples and usage
- Added Next.js test suite with fixtures

## Implementation Details
- Direct API directory scanning (app/api)
- Intelligent method detection from route handlers (GET, POST, PUT, DELETE, PATCH)
- Support for TypeScript and JavaScript route files
- Maintained existing grouping and filtering features
- Framework names are now referenced from constants.js for consistency

## Usage
```bash
# List all API routes
route-list app/api

# Group routes by path
route-list app/api --group

# Filter by HTTP methods
route-list app/api --methods GET,POST

# Filter by path
route-list app/api --include-paths /users
```

## Why This Implementation
I chose this approach because it aligns with how I structure my Next.js API routes. The implementation:
1. Points directly to the api directory for clarity
2. Scans route files to detect actual HTTP methods
3. Preserves the existing CLI interface and options
4. Maintains compatibility with other frameworks

## Testing
- Added dedicated Next.js test suite
- Created test fixtures matching real-world API patterns
- Tests both method detection and path handling
- Verified compatibility with existing features

```plaintext
> npm run test

> route-list@1.3.5 test
> node --test

✔ Express Routes (2.6805ms)
✔ Fastify Routes (4.7625ms)
✔ D:\github\route-list\test\fixtures\next-app\app\about\page.js (107.3965ms)     
✔ D:\github\route-list\test\fixtures\next-app\app\api\users\route.js (126.9189ms)
✔ D:\github\route-list\test\fixtures\next-app\app\page.js (124.4004ms)
✔ D:\github\route-list\test\fixtures\next-app\app\users\[id]\page.js (124.8508ms)
✔ D:\github\route-list\test\fixtures\next-app\app\users\page.js (125.8635ms)     
✔ Hapi Routes (2.1555ms)
✔ Koa Routes (2.1131ms)
✔ Next.js Routes (5.5734ms)      
✔ getAppWorkingDirPath (2.8925ms)
✔ getFrameworkName (1.9406ms)    
ℹ tests 12
ℹ suites 0
ℹ pass 12
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 610.1453
```

## Documentation
- Updated README with Next.js examples
- Added framework-specific notes
- Included directory structure examples
- Added programmatic usage examples

## Notes
- Only supports App Router API routes (13+)
- Framework names are now referenced from constants.js
- Automatically detects HTTP methods from route handlers
- Maintains backward compatibility

## Screenshots
This is a real example using one of my active projects
```plaintext
>node D:\github\route-list\src\cli.js ./app/api --group

  POST          /ai/batches.........................................................................................
  GET|HEAD      /ai/batches/:batchId................................................................................
  POST          /ai/batches/:batchId................................................................................
  GET|HEAD      /ai/calls...........................................................................................
  GET|HEAD      /ai/calls/:callId...................................................................................
  GET|HEAD      /ai/inbound/:phoneNumber............................................................................
  POST          /ai/inbound/:phoneNumber............................................................................
  GET|HEAD      /ai/voices..........................................................................................
  POST          /ai/voices/:voiceId/sample..........................................................................

  POST          /calls..............................................................................................

  GET|HEAD      /health.............................................................................................

  GET|HEAD      /integrations/google-calendar.......................................................................
  POST          /integrations/google-calendar.......................................................................
  GET|HEAD      /integrations/google-calendar/auth-url..............................................................
  GET|HEAD      /integrations/google-calendar/callback..............................................................
  POST          /integrations/google-calendar/disconnect............................................................

  GET|HEAD      /notifications......................................................................................
  PUT           /notifications......................................................................................

  GET|HEAD      /outbound...........................................................................................
  POST          /outbound...........................................................................................

  GET|HEAD      /phone-number.......................................................................................

  GET|HEAD      /prompts............................................................................................
  POST          /prompts............................................................................................
  DELETE        /prompts/:id........................................................................................

  Listed 24 HTTP routes.
```